### PR TITLE
Change right management on /var/www/

### DIFF
--- a/docker/delivery/Dockerfile
+++ b/docker/delivery/Dockerfile
@@ -5,6 +5,6 @@ ADD start.sh /start.sh
 RUN chmod +x /start.sh
 ADD static/ /var/www/
 
-RUN chmod -R 755 /var/www
+RUN chmod -R 755 /var/www/
 
 CMD [ "/start.sh" ]

--- a/docker/delivery/nginx.conf.tpl
+++ b/docker/delivery/nginx.conf.tpl
@@ -18,7 +18,8 @@ http {
     sendfile        on;
     tcp_nopush   on;
     keepalive_timeout  65;
-    #include /etc/nginx/conf.d/*.conf;
+
+
     server {
         listen       80;
         location ~ ^/api.* {
@@ -26,7 +27,7 @@ http {
         }
 
         location / {
-          root /var/www;
+          root /var/www/;
           index index.html;
 
             try_files $uri $uri/ /index.html;


### PR DESCRIPTION
If not done those change, Nginx return a 500 followed by 403 when tying to access to kodokojo-ui